### PR TITLE
Feat: UserContext 클래스 작성

### DIFF
--- a/src/main/java/com/kosa/realestate/users/UserContext.java
+++ b/src/main/java/com/kosa/realestate/users/UserContext.java
@@ -1,0 +1,31 @@
+package com.kosa.realestate.users;
+
+import com.kosa.realestate.users.model.Users;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+
+/**
+ * UserContext 클래스
+ * Principle 객체에 더 많은 정보를 넣기 위한 클래스
+ *
+ * @author 이주윤
+ */
+public class UserContext extends User {
+
+  private final Long userId;
+  private final String nickname;
+  private final char isDeleted;
+  private final LocalDateTime createdAt;
+  private final LocalDateTime updatedAt;
+
+  public UserContext(Users user, List<GrantedAuthority> authorities) {
+    super(user.getEmail(), user.getPassword(), authorities);
+    this.userId = user.getUserId();
+    this.nickname = user.getNickname();
+    this.isDeleted = user.getIsDeleted();
+    this.createdAt = user.getCreatedAt();
+    this.updatedAt = user.getUpdatedAt();
+  }
+}

--- a/src/main/java/com/kosa/realestate/users/controller/UserController.java
+++ b/src/main/java/com/kosa/realestate/users/controller/UserController.java
@@ -109,7 +109,7 @@ public class UserController {
   }
 
   // 회원 정보 수정 폼 저장
-//  @PostMapping("/me")
+//  @PutMapping("/me")
 //  @ResponseBody
 //  public ResponseEntity<?> updateUser(@Valid UserUpdateForm userUpdateForm, BindingResult bindingResult,
 //      Principal principal) {

--- a/src/main/java/com/kosa/realestate/users/service/UserSecurityService.java
+++ b/src/main/java/com/kosa/realestate/users/service/UserSecurityService.java
@@ -1,5 +1,6 @@
 package com.kosa.realestate.users.service;
 
+import com.kosa.realestate.users.UserContext;
 import com.kosa.realestate.users.model.Users;
 import com.kosa.realestate.users.repository.UserRepository;
 import java.util.ArrayList;
@@ -8,7 +9,6 @@ import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
-import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
@@ -42,6 +42,6 @@ public class UserSecurityService implements UserDetailsService {
     List<GrantedAuthority> authorities = new ArrayList<>();
     authorities.add(new SimpleGrantedAuthority("USER")); // 현재는 USER 권한만 존재
 
-    return new User(user.getEmail(), user.getPassword(), authorities);
+    return new UserContext(user, authorities);
   }
 }

--- a/src/main/resources/templates/login_form.html
+++ b/src/main/resources/templates/login_form.html
@@ -5,7 +5,7 @@
 	<h2>로그인</h2>
 	<form th:action="@{/users/login}" method="post">
 		<div th:if="${param.error}">
-			<div>사용자ID 또는 비밀번호를 확인해 주세요.</div>
+			<div>이메일 또는 비밀번호를 확인해 주세요.</div>
 		</div>
 		<div>
 			<input type="text" name="username" id="username"

--- a/src/main/resources/templates/signup_form.html
+++ b/src/main/resources/templates/signup_form.html
@@ -12,25 +12,25 @@
     <div th:if="${#fields.hasErrors('email')}" th:errors="*{email}">이메일 오류</div>
     <div>
       <label for="email">이메일</label>
-      <input type="email" th:field="*{email}">
+      <input type="email" id="email" th:field="*{email}">
     </div>
 
     <div th:if="${#fields.hasErrors('password1')}" th:errors="*{password1}">비밀번호 오류</div>
     <div>
       <label for="password1">비밀번호</label>
-      <input type="password" th:field="*{password1}">
+      <input type="password" id="password1" th:field="*{password1}">
     </div>
 
     <div th:if="${#fields.hasErrors('password2')}" th:errors="*{password2}">비밀번호 확인 오류</div>
     <div>
       <label for="password2">비밀번호 확인</label>
-      <input type="password" th:field="*{password2}">
+      <input type="password" id="password2" th:field="*{password2}">
     </div>
 
     <div th:if="${#fields.hasErrors('nickname')}" th:errors="*{nickname}">닉네임 오류</div>
     <div>
       <label for="nickname">닉네임</label>
-      <input type="text" th:field="*{nickname}">
+      <input type="text" id="nickname" th:field="*{nickname}">
     </div>
     <button type="submit">회원가입</button>
   </form>

--- a/src/main/resources/templates/update_form.html
+++ b/src/main/resources/templates/update_form.html
@@ -71,7 +71,7 @@
 
 <!--      $.ajax({-->
 <!--        url: "/users/me",-->
-<!--        type: "POST",-->
+<!--        type: "PUT",-->
 <!--        contentType: "application/json",-->
 <!--        data: JSON.stringify({-->
 <!--          password1: $("#password1").val(),-->


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술. 가급적이면 as-is, to-be를 활용해서 작성  -->
**AS-IS**
UserSecurityService에서 security에서 제공하는 User객체만 반환했기 때문에 다른 클래스나 thymeleaf에서 Principal 객체를 사용할 때 이메일 밖에 가져오지 못함.

**TO-BE**
Principal 객체에 User에 대한 더 많은 정보를 저장하기 위한 UserContext 객체 생성 후 UserSecurityService에서 사용하여 이제 다른 클래스나 thymeleaf에서 principal.userId, principal.nickname 등으로 쉽게 로그인한 유저의 정보를 가져올 수 있음.

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [ ] API 테스트 