### PR TITLE
탈퇴 계정 로그인 실패 기능 추가 및 폴더 이동

### DIFF
--- a/src/main/java/com/kosa/realestate/DeletedUserException.java
+++ b/src/main/java/com/kosa/realestate/DeletedUserException.java
@@ -1,0 +1,10 @@
+package com.kosa.realestate;
+
+import org.springframework.security.core.AuthenticationException;
+
+public class DeletedUserException extends AuthenticationException {
+
+  public DeletedUserException(String msg) {
+    super(msg);
+  }
+}

--- a/src/main/java/com/kosa/realestate/DuplicateUserException.java
+++ b/src/main/java/com/kosa/realestate/DuplicateUserException.java
@@ -1,4 +1,4 @@
-package com.kosa.realestate.users;
+package com.kosa.realestate;
 
 /**
  * DuplicateUserException 클래스

--- a/src/main/java/com/kosa/realestate/InvalidPasswordException.java
+++ b/src/main/java/com/kosa/realestate/InvalidPasswordException.java
@@ -1,4 +1,4 @@
-package com.kosa.realestate.users;
+package com.kosa.realestate;
 
 public class InvalidPasswordException extends RuntimeException {
   public InvalidPasswordException(String message) {

--- a/src/main/java/com/kosa/realestate/security/CustomAuthenticationFailureHandler.java
+++ b/src/main/java/com/kosa/realestate/security/CustomAuthenticationFailureHandler.java
@@ -1,0 +1,57 @@
+package com.kosa.realestate.security;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.DisabledException;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+
+/**
+ * AuthenticationFailureHandler 클래스
+ * 인증 실패 시 처리를 담당
+ * 다양한 인증 실패 상황에 대해 적절한 응답을 생성
+ */
+@Component
+public class CustomAuthenticationFailureHandler extends SimpleUrlAuthenticationFailureHandler {
+
+  private static final Logger logger = LoggerFactory.getLogger(
+      CustomAuthenticationFailureHandler.class);
+
+  @Override
+  public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response,
+      AuthenticationException exception) throws IOException, ServletException {
+
+    String errorMessage;
+
+    // CustomAuthenticationProvider 에서 던진 예외들을 받아서 errorMessage 에 담음
+    if (exception instanceof UsernameNotFoundException) {
+      errorMessage = "이메일 또는 비밀번호를 확인해 주세요.";
+      logger.info("UsernameNotFoundException occurred: {}", exception.getMessage());
+    } else if (exception instanceof DisabledException) {
+      errorMessage = exception.getMessage();
+      logger.info("DisabledException occurred: {}", errorMessage);
+    } else if (exception instanceof BadCredentialsException) {
+      errorMessage = "이메일 또는 비밀번호를 확인해 주세요.";
+      logger.info("BadCredentialsException occurred: {}", exception.getMessage());
+    } else {
+      errorMessage = "예상치 못한 인증 오류";
+      logger.error("Unexpected authentication exception", exception);
+    }
+
+    // 로그인 실패 시 이동하는 URL 지정 및 세션에 errorMessage 담아서 보냄
+    setDefaultFailureUrl("/users/login?error");
+    request.getSession().setAttribute("errorMessage", errorMessage);
+    super.onAuthenticationFailure(request, response, exception);
+
+    logger.info("Authentication failed: {}", errorMessage);
+    logger.info("Exception type: {}", exception.getClass().getName());
+    logger.info("Exception message: {}", exception.getMessage());
+  }
+}

--- a/src/main/java/com/kosa/realestate/security/CustomAuthenticationProvider.java
+++ b/src/main/java/com/kosa/realestate/security/CustomAuthenticationProvider.java
@@ -1,0 +1,67 @@
+package com.kosa.realestate.security;
+
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.DisabledException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Component;
+
+/**
+ * 실제 인증 로직을 담당하는 AuthenticationProvier 클래스
+ * UserSecurityService 를 통해 사용자 정보를 가져오고, PasswordEncoder 를 사용해 비밀번호를 검증
+ * 
+ * @author 이주윤
+ */
+@Component
+@RequiredArgsConstructor
+public class CustomAuthenticationProvider implements AuthenticationProvider {
+
+  private final UserSecurityService userSecurityService;
+  private final PasswordEncoder passwordEncoder;
+
+  private static final Logger logger = LoggerFactory.getLogger(CustomAuthenticationProvider.class);
+
+  // formLogin()에 UsernamePasswordAuthenticationFilter 가 추가되고 해당 필터가
+  // HTTP 요청에서 username 과 password 를 추출하여 UsernamePasswordAuthenticationToken 을 생성 (인증 요청용)
+  // 이 토큰은 AuthenticationManager 에 전달되고, 이는 다시 설정된 AuthenticationProvider 에 전달 됨.
+  // AuthenticationProvider 는 인증이 성공하면 UsernamePasswordAuthenticationToken 을 반환함 (인증 성공 결과 알림)
+  // (UsernamePasswordAuthenticationToken 은 Authentication 의 구현체)
+  @Override
+  public Authentication authenticate(Authentication authentication) throws AuthenticationException {
+    String email = authentication.getName();
+    String password = authentication.getCredentials().toString();
+
+    try {
+      UserContext userContext = (UserContext) userSecurityService.loadUserByUsername(email);
+
+      // 등록된 계정(탈퇴 유무 관계 없이) & 틀린 비밀번호
+      if (!passwordEncoder.matches(password, userContext.getPassword())) {
+        throw new BadCredentialsException("이메일 또는 비밀번호를 확인해 주세요.");
+      }
+
+      // 탈퇴한 계정 & 맞는 비밀번호
+      if (userContext.getIsDeleted() == 'Y') {
+        logger.info("Deleted user attempted to log in: {}", email);
+        throw new DisabledException("탈퇴한 회원입니다.");
+      }
+
+      // 탈퇴 안 한 계정 & 맞는 비밀번호 (로그인 성공)
+      return new UsernamePasswordAuthenticationToken(userContext, password, userContext.getAuthorities());
+    } catch (UsernameNotFoundException e) { // 존재하지 않는 이메일
+      logger.info("User not found: {}", email);
+      throw new BadCredentialsException("이메일 또는 비밀번호를 확인해 주세요."); // 보안상 구체적 오류 원인을 알리지 않음
+    }
+  }
+
+  @Override
+  public boolean supports(Class<?> authentication) {
+    return authentication.equals(UsernamePasswordAuthenticationToken.class);
+  }
+}

--- a/src/main/java/com/kosa/realestate/security/PasswordEncoderConfig.java
+++ b/src/main/java/com/kosa/realestate/security/PasswordEncoderConfig.java
@@ -1,0 +1,15 @@
+package com.kosa.realestate.security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class PasswordEncoderConfig {
+
+  @Bean
+  PasswordEncoder passwordEncoder() {
+    return new BCryptPasswordEncoder();
+  }
+}

--- a/src/main/java/com/kosa/realestate/security/SecurityConfig.java
+++ b/src/main/java/com/kosa/realestate/security/SecurityConfig.java
@@ -1,5 +1,6 @@
-package com.kosa.realestate;
+package com.kosa.realestate.security;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -15,25 +16,35 @@ import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 /**
  * SecurityConfig 클래스
  *
+ * 애플리케이션이 실행될 때 @Configuration 어노테이션이 붙은 클래스들이 처리됨
+ * 이때 filterChain() 메서드가 실행되면서 필터체인이 구성됨
+ * 이후 HTTP 요청이 들어오면 미리 구성된 필터 체인을 통과하면서 정의된 설정에 따라 처리됨
+ * 즉, 구성 순서와 실행 순서는 다름
+ * 
  * @author 이주윤
  */
 @Configuration
 @EnableWebSecurity
+@RequiredArgsConstructor
 public class SecurityConfig {
+
+  private final CustomAuthenticationProvider authenticationProvider;
+  private final CustomAuthenticationFailureHandler failureHandler;
 
   @Bean
   SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-    http.authorizeHttpRequests((authorizeHttpRequests) -> authorizeHttpRequests
-            // .requestMatchers(new AntPathRequestMatcher("/users/me")).hasAnyRole("USER", "AGENT")
-            // .anyRequest().permitAll())
-            .requestMatchers(new AntPathRequestMatcher("/**")).permitAll()) // 모든 URL 패턴에 대해 접근을 허용
+    http
+        .authenticationProvider(authenticationProvider)
+        .authorizeHttpRequests((authorizeHttpRequests) -> authorizeHttpRequests
+            .requestMatchers(new AntPathRequestMatcher("/**")).permitAll())
         .headers((headers) -> headers
             .addHeaderWriter(new XFrameOptionsHeaderWriter(
                 XFrameOptionsHeaderWriter.XFrameOptionsMode.SAMEORIGIN)))
         .formLogin((formLogin) -> formLogin
             .loginPage("/users/login")
+            .failureHandler(failureHandler)
             .defaultSuccessUrl("/"))
-        .logout((logout) -> logout    // 로그아웃 설정
+        .logout((logout) -> logout
             .logoutRequestMatcher(new AntPathRequestMatcher("/users/logout"))
             .logoutSuccessUrl("/")
             .invalidateHttpSession(true))
@@ -42,15 +53,11 @@ public class SecurityConfig {
     return http.build();
   }
 
-  @Bean
-  PasswordEncoder passwordEncoder() {
-    return new BCryptPasswordEncoder();
-  }
-
   // AuthenticationManager 는 스프링 시큐리티의 인증을 처리함.
   @Bean
   AuthenticationManager authenticationManager(
       AuthenticationConfiguration authenticationConfiguration) throws Exception {
+    
     return authenticationConfiguration.getAuthenticationManager();
   }
 }

--- a/src/main/java/com/kosa/realestate/security/UserContext.java
+++ b/src/main/java/com/kosa/realestate/security/UserContext.java
@@ -1,4 +1,4 @@
-package com.kosa.realestate.users;
+package com.kosa.realestate.security;
 
 import com.kosa.realestate.users.model.Users;
 import java.time.LocalDateTime;

--- a/src/main/java/com/kosa/realestate/security/UserRole.java
+++ b/src/main/java/com/kosa/realestate/security/UserRole.java
@@ -1,4 +1,4 @@
-package com.kosa.realestate.users;
+package com.kosa.realestate.security;
 
 import lombok.Getter;
 

--- a/src/main/java/com/kosa/realestate/security/UserSecurityService.java
+++ b/src/main/java/com/kosa/realestate/security/UserSecurityService.java
@@ -1,13 +1,12 @@
-package com.kosa.realestate.users.service;
+package com.kosa.realestate.security;
 
-import com.kosa.realestate.users.UserContext;
-import com.kosa.realestate.users.UserRole;
 import com.kosa.realestate.users.model.Users;
 import com.kosa.realestate.users.repository.UserRepository;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -17,6 +16,8 @@ import org.springframework.stereotype.Service;
 
 /**
  * UserSecurityService 클래스
+ * 사용자 정보를 DB에서 가져오는 역할
+ * loadUserByUsername 메서드를 구현하여 사용자 정보를 UserDetails 객체로 반환
  *
  * @author 이주윤
  */
@@ -26,23 +27,22 @@ import org.springframework.stereotype.Service;
 public class UserSecurityService implements UserDetailsService {
 
   private final UserRepository userRepository;
+  private static final Logger logger = LoggerFactory.getLogger(UserSecurityService.class);
 
   @Override
   public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
-    Optional<Users> _user = userRepository.findUserByEmail(email);
-    if (_user.isEmpty()) {
-      throw new UsernameNotFoundException("사용자를 찾을 수 없습니다.");
-    }
+    logger.info("Attempting to load user by email: {}", email);
 
-    if (_user.get().getIsDeleted() == 'Y') {
-      throw new UsernameNotFoundException("탈퇴한 회원입니다.");
-    }
+    Users user = userRepository.findUserByEmail(email)
+        .orElseThrow(() -> {  // 입력한 이메일에 매칭되는 User 가 없을 때 UsernameNotFoundException 던짐
+          logger.info("User not found for email: {}", email);
+          return new UsernameNotFoundException("사용자를 찾을 수 없습니다.");
+        });
 
-    Users user = _user.get();
     String accountType = user.getAccountType();
     List<GrantedAuthority> authorities = new ArrayList<>();
 
-    if("admin".equals(accountType)) {
+    if ("admin".equals(accountType)) {
       authorities.add(new SimpleGrantedAuthority(UserRole.ADMIN.getValue()));
     } else if ("agent".equals(accountType)) {
       authorities.add(new SimpleGrantedAuthority(UserRole.AGENT.getValue()));
@@ -50,6 +50,7 @@ public class UserSecurityService implements UserDetailsService {
       authorities.add(new SimpleGrantedAuthority(UserRole.USER.getValue()));
     }
 
+    logger.info("User loaded successfully: {}", email);
     return new UserContext(user, authorities);
   }
 }

--- a/src/main/java/com/kosa/realestate/users/controller/UserController.java
+++ b/src/main/java/com/kosa/realestate/users/controller/UserController.java
@@ -25,8 +25,8 @@ import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 import com.kosa.realestate.favorites.model.dto.FavoriteListDTO;
 import com.kosa.realestate.favorites.service.FavoriteService;
-import com.kosa.realestate.users.DuplicateUserException;
-import com.kosa.realestate.users.InvalidPasswordException;
+import com.kosa.realestate.DuplicateUserException;
+import com.kosa.realestate.InvalidPasswordException;
 import com.kosa.realestate.users.form.UserCreateForm;
 import com.kosa.realestate.users.form.UserUpdateForm;
 import com.kosa.realestate.users.model.UserDTO;
@@ -101,6 +101,7 @@ public class UserController {
 
     String email = principal.getName();
     UserDTO userDTO = userService.findUserByEmail(email);
+
     model.addAttribute("user", userDTO);
 
     List<FavoriteListDTO> favoriteListDtoList = favoriteService.findFavoriteList(0, email);
@@ -109,16 +110,6 @@ public class UserController {
     // TODO: my_page.html에서 AJAX 도입해서 페이지네이션
     return "my-page";
   }
-
-  // 회원 정보 수정 페이지로 이동 -> 마이페이지에서 모달창으로 띄워주는 방식으로 변경됨
-//  @GetMapping("/me/update")
-//  public String updateUser(Principal principal, UserUpdateForm userUpdateForm) {
-//    if (principal == null) {
-//      return "access_denied";
-//    }
-//
-//    return "update_form";
-//  }
 
   // 회원 정보 수정
   @PutMapping("/me")

--- a/src/main/java/com/kosa/realestate/users/service/UserService.java
+++ b/src/main/java/com/kosa/realestate/users/service/UserService.java
@@ -10,8 +10,8 @@ import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import com.kosa.realestate.users.DuplicateUserException;
-import com.kosa.realestate.users.InvalidPasswordException;
+import com.kosa.realestate.DuplicateUserException;
+import com.kosa.realestate.InvalidPasswordException;
 import com.kosa.realestate.users.UserMapper;
 import com.kosa.realestate.users.common.CustomExceptionHandler;
 import com.kosa.realestate.users.model.UserDTO;
@@ -38,8 +38,11 @@ public class UserService implements IUserService {
   // User 생성
   public void createUser(String email, String password, String nickname) {
 
-    Users user = Users.builder().email(email).password(passwordEncoder.encode(password)) // 비밀번호 암호화
-        .nickname(nickname).build();
+    Users user = Users.builder()
+        .email(email)
+        .password(passwordEncoder.encode(password)) // 비밀번호 암호화
+        .nickname(nickname)
+        .build();
 
     // user가 작성한 email, nickname이 DB에 있는 데이터와 중복되는지 확인
     try {
@@ -65,13 +68,15 @@ public class UserService implements IUserService {
   public List<UserDTO> getUserList() {
     List<Users> usersList = userRepository.getUserList();
 
-    return usersList.stream().map(UserMapper::toDTO).collect(Collectors.toList());
+    return usersList.stream()
+        .map(UserMapper::toDTO)
+        .collect(Collectors.toList());
   }
 
   // User 업데이트
   public boolean updateUser(String email, String password) throws UsernameNotFoundException {
     Optional<Users> _user = userRepository.findUserByEmail(email);
-    if(_user.isEmpty()) {
+    if (_user.isEmpty()) {
       throw new UsernameNotFoundException("사용자를 찾을 수 없습니다.");
     }
     Users user = _user.get();
@@ -85,12 +90,12 @@ public class UserService implements IUserService {
   // User 삭제 (soft delete)
   public boolean deleteUser(String email, String password) throws UsernameNotFoundException {
     Optional<Users> _user = userRepository.findUserByEmail(email);
-    if(_user.isEmpty()) {
+    if (_user.isEmpty()) {
       throw new UsernameNotFoundException("사용자를 찾을 수 없습니다.");
     }
     Users user = _user.get();
 
-    if(!passwordEncoder.matches(password, user.getPassword())) {
+    if (!passwordEncoder.matches(password, user.getPassword())) {
       throw new InvalidPasswordException("비밀번호가 잘못되었습니다.");
     }
 
@@ -101,30 +106,30 @@ public class UserService implements IUserService {
   // 이메일 기준 사용자 정보 조회 (MyBatis)
   public UserDTO findUserByEmail(String email) throws UsernameNotFoundException {
     Optional<Users> _user = userRepository.findUserByEmail(email);
-    if(_user.isEmpty()) {
+    if (_user.isEmpty()) {
       throw new UsernameNotFoundException("사용자를 찾을 수 없습니다.");
     }
 
     return UserMapper.toDTO(_user.get()); // Users 객체를 UserDTO 로 변환 후 반환
   }
-  
+
   //사용자 중개자 권한 요청
   public boolean requestPermission(Long userId) {
-      try{
-          int result = userRepository.requestPermission(userId);
-          return result > 0;
-      } catch (PersistenceException e) {
-          log.error("Error requesting permission for user with ID {}: {}", userId, e.getMessage());
-          return false;
-      }
+    try {
+      int result = userRepository.requestPermission(userId);
+      return result > 0;
+    } catch (PersistenceException e) {
+      log.error("Error requesting permission for user with ID {}: {}", userId, e.getMessage());
+      return false;
+    }
   }
-  
+
   //관리자가 권한요청 리스트를 조회
   @Override
   public List<Map<String, Object>> selectUpgradeRequests(int startPage, int limit) {
     int offset = (startPage - 1) * limit;
     try {
-      List<Map<String,Object>> resultList = userRepository.selectUpgradeRequests(offset, limit);
+      List<Map<String, Object>> resultList = userRepository.selectUpgradeRequests(offset, limit);
       return resultList;
     } catch (PersistenceException e) {
       // 로그에 예외 정보 기록
@@ -132,33 +137,35 @@ public class UserService implements IUserService {
     }
     return null;
   }
+
   //중개자 리시트 조회
   @Override
   public List<UserDTO> searchAgentList(String nickname, int startNum) {
-      int limit = 10;
-      int offset = (startNum-1) * limit;
+    int limit = 10;
+    int offset = (startNum - 1) * limit;
     return userRepository.searchAgentList(nickname, offset, limit);
   }
-  
+
   //권한 UDATE
   @Override
   @Transactional(rollbackFor = PersistenceException.class)
   public int updateUserAccountType(List<Long> userId) {
     int requestCount = userId.size();
     int resultCount = userRepository.updateUserAccountType(userId);
- 
+
     if (requestCount != resultCount) {
-      String errorMessage = String.format("요청된 개수(%d)와 업데이트된 개수(%d)가 일치하지 않습니다.", requestCount, resultCount);
+      String errorMessage = String.format("요청된 개수(%d)와 업데이트된 개수(%d)가 일치하지 않습니다.", requestCount,
+          resultCount);
       throw new CustomExceptionHandler(errorMessage);
     }
-    
+
     // 업데이트 성공 후, 사용자 목록에서 삭제
-    for (Long Id: userId) {
+    for (Long Id : userId) {
       userRepository.deleteUpgradeRequest(Id);
     }
     return resultCount;
   }
-  
+
   //권한 요청 거절 
   @Override
   @Transactional(rollbackFor = PersistenceException.class)
@@ -170,13 +177,13 @@ public class UserService implements IUserService {
       log.error("업그레이드 요청 삭제 중 오류 발생", e);
       return false; // 오류가 발생했음을 나타내는 false 반환
     }
-    
+
   }
-  
+
   //권한 UPDATE agent -> nomal
   @Override
   public int updateRoleToNormal(List<Long> userId) {
     return userRepository.updateRoleToNormal(userId);
   }
-  
+
 }

--- a/src/main/resources/templates/login.html
+++ b/src/main/resources/templates/login.html
@@ -18,7 +18,7 @@
         <div class="card-body">
           <h2 class="card-title text-center mb-4">로그인</h2>
           <div th:if="${param.error}" class="alert alert-danger mb-4">
-            <div>이메일 또는 비밀번호를 확인해 주세요.</div>
+            <div th:text="${session.errorMessage}"></div>
           </div>
           <form th:action="@{/users/login}" method="post">
             <div class="mb-4">


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술. 가급적이면 as-is, to-be를 활용해서 작성  -->
**AS-IS**
* 탈퇴 계정이 로그인 했을 때 "이메일 또는 비밀번호를 확인해 주세요." 라는 메시지가 떴음
* users 패키지에 시큐리티 관련 클래스들이 혼재
* users 패키지에 Exception 패키지들 혼재

**TO-BE**
* 이제 탈퇴 계정이 로그인을 시도하면 "탈퇴한 회원입니다." 라는 메시지를 화면에 보여줍니다.
* users 패키지에 들어있던 시큐리티 관련 클래스들을 security 패키지에 옮겼습니다.
* users 패키지 내의 Exception 클래스들을 com.kosa.realestate 패키지로 옮겼습니다.

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [x] API 테스트 